### PR TITLE
Root build fix and OAuthFile command line argument validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,8 +107,6 @@ project(":TweetWallFX-JavaOne"){
 
 project(":TweetWallFX-Generic2D"){
     
-    apply plugin: "java"
-    
 //    run {
 //        mainClassName = "org.tweetwallfx.generic.Main"        
 //        args = [

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ project(":TweetWallFX-JavaOne"){
 
 project(":TweetWallFX-Generic2D"){
     
-    apply plugin: "application"
+    apply plugin: "java"
     
 //    run {
 //        mainClassName = "org.tweetwallfx.generic.Main"        

--- a/core/src/main/java/org/tweetwallfx/cmdargs/FileExistsValueValidator.java
+++ b/core/src/main/java/org/tweetwallfx/cmdargs/FileExistsValueValidator.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014-2015 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.cmdargs;
+
+import com.beust.jcommander.IValueValidator;
+import com.beust.jcommander.ParameterException;
+import java.io.File;
+
+/**
+ * Parameter value validator for files that checks if the declared
+ * {@link java.io.File} exists. If that is not the case then a
+ * {@link com.beust.jcommander.ParameterException} will be thrown.
+ *
+ * @author martin
+ */
+public class FileExistsValueValidator implements IValueValidator<File> {
+
+    @Override
+    public void validate(String string, File t) throws ParameterException {
+        if (null == t) {
+            throw new ParameterException(string + " is not set!");
+        } else if (!t.exists()) {
+            throw new ParameterException(t.getAbsolutePath() + " does not exist!");
+        }
+    }
+}

--- a/core/src/main/java/org/tweetwallfx/cmdargs/RegularFileValueValidator.java
+++ b/core/src/main/java/org/tweetwallfx/cmdargs/RegularFileValueValidator.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014-2015 TweetWallFX
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tweetwallfx.cmdargs;
+
+import com.beust.jcommander.ParameterException;
+import java.io.File;
+
+/**
+ * Parameter value validator for files that checks if the declared
+ * {@link java.io.File} exists and is a regular {@link java.io.File}. If that is
+ * not the case then a {@link com.beust.jcommander.ParameterException} will be
+ * thrown.
+ *
+ * @author martin
+ */
+public class RegularFileValueValidator extends FileExistsValueValidator {
+
+    @Override
+    public void validate(String string, File t) throws ParameterException {
+        super.validate(string, t);
+
+        if (!t.isFile()) {
+            throw new ParameterException(t.getAbsolutePath() + " is not a regular file!");
+        }
+    }
+}

--- a/core/src/main/java/org/tweetwallfx/twitter/TwitterOAuth.java
+++ b/core/src/main/java/org/tweetwallfx/twitter/TwitterOAuth.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Properties;
 import org.openide.util.lookup.ServiceProvider;
 import org.tweetwallfx.cmdargs.CommandLineArgumentParser;
+import org.tweetwallfx.cmdargs.RegularFileValueValidator;
 import twitter4j.Twitter;
 import twitter4j.TwitterException;
 import twitter4j.TwitterFactory;
@@ -84,10 +85,6 @@ public class TwitterOAuth {
             } else {
                 System.out.println("Using authentication information from provided file: " + Params.oAuthFile.getAbsolutePath());
 
-                if (!Params.oAuthFile.exists()) {
-                    throw new IllegalArgumentException("Provided authentication file does not exist!");
-                }
-
                 try (final FileReader fr = new FileReader(Params.oAuthFile)) {
                     props.load(fr);
                 }
@@ -139,7 +136,7 @@ public class TwitterOAuth {
     @ServiceProvider(service = CommandLineArgumentParser.ParametersObject.class)
     public static final class Params implements CommandLineArgumentParser.ParametersObject {
 
-        @Parameter(names = "-oAuthFile", description = "File with OAuth Properties")
+        @Parameter(names = "-oAuthFile", description = "File with OAuth Properties", validateValueWith = RegularFileValueValidator.class)
         private static File oAuthFile;
     }
 }


### PR DESCRIPTION
Build of root project failed due to missing mainClassName of Generic2D subproject.
The -oAuthFile command line argument is now validated that the declared file really exists.